### PR TITLE
Update the iso to use ubuntu's image with the correct sha256

### DIFF
--- a/template.json
+++ b/template.json
@@ -2,8 +2,8 @@
     "builders": [
         {
             "type": "virtualbox-iso",
-            "iso_url": "http://ftp.heanet.ie/pub/ubuntu-releases/14.04.2/ubuntu-14.04.2-server-amd64.iso",
-            "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
+            "iso_url": "http://releases.ubuntu.com/14.04.3/ubuntu-14.04.3-server-amd64.iso",
+            "iso_checksum": "a3b345908a826e262f4ea1afeb357fd09ec0558cf34e6c9112cead4bb55ccdfb",
             "iso_checksum_type": "sha256",
             "boot_wait": "5s",
             "boot_command": [


### PR DESCRIPTION
The sha wasn't correct with the previous image. I suppose that could
mean it didn't download correctly, but seeing as I was getting errors on
more than on network, I'm going to assume the link is stale.